### PR TITLE
add Makefile; compile fava using PyInstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+build
+bin
+
 # Logs
 logs
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: src utils
+
+all: bin/fava node_modules
+
+node_modules:
+	npm install
+
+bin/fava: build/fava
+	cd build/fava; git fetch; git reset --hard origin/master
+	make -C build/fava
+	make -C build/fava pyinstaller
+	mkdir -p bin
+	cp build/fava/dist/fava bin/fava
+
+build/fava:
+	git clone git@github.com:aumayr/fava.git build/fava
+
+clean:
+	rm -rf build bin
+	rm -rf node_modules
+
+icons:
+	iconutil -c icns utils/FavaDesktop.iconset
+
+app:
+	./node_modules/.bin/electron-packager . Fava --platform=darwin --arch=x64 --icon=utils/FavaDesktop.icns --overwrite

--- a/README.md
+++ b/README.md
@@ -2,17 +2,7 @@
 
 [`Electron`](http://electron.atom.io)-wrapper for [`fava`](https://github.com/aumayr/fava).
 
-Run with `electron .`
-
-## Development
-
-To generate icons:
-
-    $ iconutil -c icns FavaDesktop.iconset
-
-To pack the application (on a Mac):
-
-    $ electron-packager . Fava --platform=darwin --arch=x64 --icon=utils/FavaDesktop.icns --overwrite
+Run `make` to setup and start with `npm start`.
 
 ---
 **Caution**: This is far from finished. Consider it *alpha*-software. Contributions are very welcome :-)

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "electron-prebuilt": "^1.1.3",
     "electron-settings": "*",
     "request-promise": "*"
+  },
+  "scripts": {
+    "start": "electron ."
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -48,7 +48,7 @@ app.on('ready', function() {
         // '--settings', settings.get('fava-settings-file')
     ];
     console.log('fava', processDescription);
-    var subpy = require('child_process').spawn('fava', processDescription);
+    var subpy = require('child_process').spawn(app.getAppPath() + '/bin/fava', processDescription);
 
     subpy.on('error', (err) => {
       console.log('Failed to start child process.');


### PR DESCRIPTION
This compiles fava to `bin/fava`. Currently breaks `electron-packager`, but it shouldn't be too hard to tell it to include the binary...

I quite like `fava-electron`. I think this is the way to make fava installable for everyone.
